### PR TITLE
[DO-NOT-MERGE]: Use ListObjectsPages instead of "buggy" ListObjectsV2Pages

### DIFF
--- a/velero-plugin-for-aws/object_store.go
+++ b/velero-plugin-for-aws/object_store.go
@@ -55,6 +55,7 @@ const (
 type s3Interface interface {
 	HeadObject(input *s3.HeadObjectInput) (*s3.HeadObjectOutput, error)
 	GetObject(input *s3.GetObjectInput) (*s3.GetObjectOutput, error)
+	ListObjectsPages(input *s3.ListObjectsInput, fn func(*s3.ListObjectsOutput, bool) bool) error
 	ListObjectsV2Pages(input *s3.ListObjectsV2Input, fn func(*s3.ListObjectsV2Output, bool) bool) error
 	DeleteObject(input *s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error)
 	GetObjectRequest(input *s3.GetObjectInput) (req *request.Request, output *s3.GetObjectOutput)
@@ -314,14 +315,14 @@ func (o *ObjectStore) GetObject(bucket, key string) (io.ReadCloser, error) {
 }
 
 func (o *ObjectStore) ListCommonPrefixes(bucket, prefix, delimiter string) ([]string, error) {
-	req := &s3.ListObjectsV2Input{
+	req := &s3.ListObjectsInput{
 		Bucket:    &bucket,
 		Prefix:    &prefix,
 		Delimiter: &delimiter,
 	}
 
 	var ret []string
-	err := o.s3.ListObjectsV2Pages(req, func(page *s3.ListObjectsV2Output, lastPage bool) bool {
+	err := o.s3.ListObjectsPages(req, func(page *s3.ListObjectsOutput, lastPage bool) bool {
 		for _, prefix := range page.CommonPrefixes {
 			ret = append(ret, *prefix.Prefix)
 		}


### PR DESCRIPTION
The use of *V2* API is recommended in the docs, however, I
can prove that the ListObjectsV2Pages was returning only
555 Prefixes instead of 786.

The ListObjectsPages and s3cmd cli is implemented using
`Marker` in the prefix list instead of the continuation
token (ListObjectsV2Pages) implementation. The former
has proven to give consistent results with this bucket and
the later is source of bugs for us.