### PR TITLE
Updating aws plugin image to support multi-arch builds

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.14.7 AS build
+FROM quay.io/konveyor/builder as builder
 ENV GOPATH=$APP_ROOT
 COPY . $APP_ROOT/src/velero-plugin-for-aws
 WORKDIR $APP_ROOT/src/velero-plugin-for-aws
@@ -7,6 +7,6 @@ RUN CGO_ENABLED=0 GOOS=linux go build -v -o $APP_ROOT/bin/velero-plugin-for-aws 
 
 FROM registry.access.redhat.com/ubi8-minimal
 RUN mkdir /plugins
-COPY --from=build /opt/app-root/bin/velero-plugin-for-aws /plugins/
+COPY --from=builder /opt/app-root/bin/velero-plugin-for-aws /plugins/
 USER nobody:nobody
 ENTRYPOINT ["/bin/bash", "-c", "cp /plugins/* /target/."]


### PR DESCRIPTION
Updated aws plugin image source to use the new konveyor/builder image to support multi-arch builds