### PR TITLE
OADP-4254: `snapshot.State == ""` typo

### DIFF
--- a/velero-plugin-for-aws/volume_snapshotter.go
+++ b/velero-plugin-for-aws/volume_snapshotter.go
@@ -154,7 +154,7 @@ func (b *VolumeSnapshotter) snapshotWhenAvailable(snapshotID string) (*types.Sna
 		if err != nil {
 			return true, err
 		}
-		if snapshot.State != "" {
+		if snapshot.State == "" {
 			snapshot = nil
 			logger.Debug("snapshot has empty state")
 			return true, errors.Errorf("Snapshot has empty state")


### PR DESCRIPTION
How container was built: `docker build -f Dockerfile.ubi -t ghcr.io/kaovilai/velero-plugin-for-aws:oadp-1.4-velero-release-1.10-2 --platform=linux/amd64 .`

container image: `quay.io/rhn_engineering_whayutin/oadp-velero-plugin-for-aws-pr51:latest`

Wes showed this image worked against a simple VSL snapshot test.

Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>
