### PR TITLE
fix: ARM images

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -1,9 +1,14 @@
 FROM quay.io/konveyor/builder:ubi9-latest AS builder
-ENV GOPATH=$APP_ROOT
-COPY . $APP_ROOT/src/velero-plugin-for-aws
-WORKDIR $APP_ROOT/src/velero-plugin-for-aws
-RUN CGO_ENABLED=0 GOOS=linux go build -v -o $APP_ROOT/bin/velero-plugin-for-aws -mod=mod ./velero-plugin-for-aws
+ARG TARGETOS
+ARG TARGETARCH
 
+ENV GOPATH=$APP_ROOT
+
+COPY . $APP_ROOT/src/velero-plugin-for-aws
+
+WORKDIR $APP_ROOT/src/velero-plugin-for-aws
+
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -v -o $APP_ROOT/bin/velero-plugin-for-aws -mod=mod ./velero-plugin-for-aws
 
 FROM registry.access.redhat.com/ubi9-minimal
 RUN mkdir /plugins


### PR DESCRIPTION
Add ARM images to PROW CI

Example image: https://quay.io/repository/msouzaol/velero-plugin-for-aws

Related to https://github.com/openshift/release/pull/54877

### How to build
```sh
docker build -t <TAG> -f Dockerfile.ubi . --platform=linux/arm64
```