### PR TITLE
Allow checksumAlgorithm param for 1.9+ aws plugin config compatibility

### DIFF
--- a/velero-plugin-for-aws/object_store.go
+++ b/velero-plugin-for-aws/object_store.go
@@ -54,6 +54,8 @@ const (
 	insecureSkipTLSVerifyKey     = "insecureSkipTLSVerify"
 	caCertKey                    = "caCert"
 	enableSharedConfigKey        = "enableSharedConfig"
+	checksumAlgKey               = "checksumAlgorithm"
+
 )
 
 type s3Interface interface {
@@ -102,6 +104,7 @@ func (o *ObjectStore) Init(config map[string]string) error {
 		serverSideEncryptionKey,
 		insecureSkipTLSVerifyKey,
 		enableSharedConfigKey,
+		checksumAlgKey, // validate but don't use, for compatibility with config for 1.9+
 	); err != nil {
 		return err
 	}


### PR DESCRIPTION
Note: do not merge. This is for testing -- the actual commit will be merged to the to-be-created velero-plugin-for-legacy-aws fork.