### PR TITLE
OADP-5388: velero#225 Various SSE-C & MD5 Hash fixes

### DIFF
--- a/backupstoragelocation.md
+++ b/backupstoragelocation.md
@@ -74,12 +74,13 @@ spec:
     kmsKeyId: "502b409c-4da1-419f-a16e-eif453b3i49f"
     
     # Specify the file that contains the SSE-C customer key to enable customer key encryption of the backups
-    # stored in S3. The referenced file should contain a 32-byte string.
+    # stored in S3. The referenced file should exist within the velero container and
+    # should contain a 32-byte string. It is typically mounted from a secret.
     #  
-    # The customerKeyEncryptionFile points to a mounted secret within the velero container.
-    # Add the below values to the velero cloud-credentials secret:
+    # Eg. add to the velero "cloud-credentials" secret this entry with the base64 encoded key
+    # (will be decoded when the secret is mounted)
     # customer-key: <your_b64_encoded_32byte_string>
-    # The default value below points to the already mounted secret.
+    # The value below points to the already mounted secret. 
     # 
     # Cannot be used in conjunction with kmsKeyId.
     #

--- a/velero-plugin-for-aws/object_store.go
+++ b/velero-plugin-for-aws/object_store.go
@@ -240,7 +240,7 @@ func readCustomerKey(customerKeyEncryptionFile string) (string, error) {
 	fileHandle.Close()
 
 	if nBytes != 32 {
-		return "", errors.Wrapf(err, "contents of %s (%s) are not exactly 32 bytes", customerKeyEncryptionFileKey, customerKeyEncryptionFile)
+		return "", fmt.Errorf("contents of %s (%s) are not exactly 32 bytes", customerKeyEncryptionFileKey, customerKeyEncryptionFile)
 	}
 
 	key := string(keyBytes)

--- a/velero-plugin-for-aws/object_store.go
+++ b/velero-plugin-for-aws/object_store.go
@@ -245,7 +245,7 @@ func readCustomerKey(customerKeyEncryptionFile string) (string, error) {
 	fileHandle.Close()
 
 	if nBytes != 32 {
-		return "", fmt.Errorf("contents of %s (%s) are not exactly 32 bytes", customerKeyEncryptionFileKey, customerKeyEncryptionFile)
+		return "", errors.Errorf("contents of %s (%s) are not exactly 32 bytes", customerKeyEncryptionFileKey, customerKeyEncryptionFile)
 	}
 
 	key := string(keyBytes)

--- a/velero-plugin-for-aws/object_store.go
+++ b/velero-plugin-for-aws/object_store.go
@@ -18,6 +18,8 @@ package main
 
 import (
 	"context"
+	"crypto/md5"
+	"encoding/base64"
 	"fmt"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
@@ -72,6 +74,7 @@ type ObjectStore struct {
 	s3Uploader           *manager.Uploader
 	kmsKeyID             string
 	sseCustomerKey       string
+	sseCustomerKeyMd5    string
 	signatureVersion     string
 	serverSideEncryption string
 	tagging              string
@@ -184,7 +187,9 @@ func (o *ObjectStore) Init(config map[string]string) error {
 		if err != nil {
 			return err
 		}
-		o.sseCustomerKey = customerKey
+		o.sseCustomerKey = base64.StdEncoding.EncodeToString([]byte(customerKey))
+		hash := md5.Sum([]byte(customerKey))
+		o.sseCustomerKeyMd5 = base64.StdEncoding.EncodeToString(hash[:])
 	}
 
 	if publicURL != "" {
@@ -265,6 +270,7 @@ func (o *ObjectStore) PutObject(bucket, key string, body io.Reader) error {
 	case o.sseCustomerKey != "":
 		input.SSECustomerAlgorithm = aws.String("AES256")
 		input.SSECustomerKey = &o.sseCustomerKey
+		input.SSECustomerKeyMD5 = &o.sseCustomerKeyMd5
 	// otherwise, use the SSE algorithm specified, if any
 	case o.serverSideEncryption != "":
 		input.ServerSideEncryption = types.ServerSideEncryption(o.serverSideEncryption)
@@ -296,6 +302,7 @@ func (o *ObjectStore) ObjectExists(bucket, key string) (bool, error) {
 	if o.sseCustomerKey != "" {
 		input.SSECustomerAlgorithm = aws.String("AES256")
 		input.SSECustomerKey = &o.sseCustomerKey
+		input.SSECustomerKeyMD5 = &o.sseCustomerKeyMd5
 	}
 
 	log.Debug("Checking if object exists")
@@ -327,6 +334,7 @@ func (o *ObjectStore) GetObject(bucket, key string) (io.ReadCloser, error) {
 	if o.sseCustomerKey != "" {
 		input.SSECustomerAlgorithm = aws.String("AES256")
 		input.SSECustomerKey = &o.sseCustomerKey
+		input.SSECustomerKeyMD5 = &o.sseCustomerKeyMd5
 	}
 
 	output, err := o.s3.GetObject(context.Background(), input)


### PR DESCRIPTION
- **fixed wrong errorhandling for customerKey size check**
- **fixed missing ssec: base64 encoding and md5 hash were missing**
- **updatd customerKey errorhandling**
- **updated backupstoragelocation-readme regarding customerKeyEncryptionFile**

Cherry-pick https://github.com/vmware-tanzu/velero-plugin-for-aws/pull/225 to oadp-1.4

```
db_multip -f Dockerfile.ubi .
db_multip='docker buildx build --platform linux/amd64,linux/arm64 --tag $(ghcr_tag) --push'
```

```
ghcr.io/kaovilai/velero-plugin-for-aws:velero225oadp-1.4
```